### PR TITLE
[PR] Fix typo in class name

### DIFF
--- a/includes/class-wsuwp-youtube-embed.php
+++ b/includes/class-wsuwp-youtube-embed.php
@@ -76,7 +76,7 @@ class WSUWP_YouTube_Embed {
 		?>
 		<!-- Embedded with wsuwp_youtube shortcode. -->
 		<div class="wsuwp-youtube-wrap-outer">
-			<div class="wuswp-youtube-wrap-inner">
+			<div class="wsuwp-youtube-wrap-inner">
 				<div class="wsuwp-youtube-embed"
 				     id="wsuwp-youtube-video-<?php echo esc_attr( $atts['video_id'] ); ?>"
 				     data-video-id="<?php echo esc_attr( $atts['video_id'] ); ?>"


### PR DESCRIPTION
Just noticed this - kicking myself for missing it during review.

It's fairly minor, but if it's worth fixing, now might the best time. The only site I know for sure that's targeting it is why.wsu.edu, so it's already prepped for the change if we make it.